### PR TITLE
Updated zabbix-ldap.conf

### DIFF
--- a/zabbix-ldap.conf
+++ b/zabbix-ldap.conf
@@ -2,12 +2,11 @@
 type = activedirectory
 uri = ldaps://ldap.example.org:636/
 base = dc=example,dc=org
-ldap_user = ldapuser
-ldap_pass = ldappass
-groups = sysadmins
+binduser = DOMAIN\ldapuser
+bindpass = ldappass
+groups = sysadmins,other_group_with_access
 
 [zabbix]
 server = http://zabbix.example.org/zabbix/
 username = admin
 password = adminp4ssw0rd
-


### PR DESCRIPTION
The option parsed by the python script is binduser/bindpass, not ldap_user/ldap_pass.

Also added a hint to include the DOMAIN for the binduser and another group so that it is clear that ',' is the separator for multiple groups.
