### PR TITLE
Fixed: #16, #18. Implemented: #12, #17, #19

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,28 @@ In order to use the *zabbix-ldap-sync* script we need to create a configuration 
 	bindpass = ldappass
 	groups = sysadmins
 
+    [user]
+    type = 1
+
 	[zabbix]
 	server = http://zabbix.example.org/zabbix/
 	username = admin
 	password = adminp4ssw0rd
+
+`[user]` section is optional. It can be used to set custom properties for Zabbix user created by script. See [User object](https://www.zabbix.com/documentation/3.2/manual/api/reference/user/object) in Zabbix API documentation for available properties.
+
+## Command-line arguments
+
+    Usage: zabbix-ldap-sync [-ls] -f <config>
+           zabbix-ldap-sync -v
+           zabbix-ldap-sync -h
+    
+    Options:
+      -h, --help                    Display this usage info
+      -v, --version                 Display version and exit
+      -l, --lowercase               Create AD user names as lowercase
+      -s, --skip-disabled           Skip disabled AD users
+      -f <config>, --file <config>  Configuration file to use
 
 ## Importing LDAP users into Zabbix
 

--- a/README.md
+++ b/README.md
@@ -18,28 +18,79 @@ Check the official documentation of Zabbix on how to
 
 ## Configuration
 
-In order to use the *zabbix-ldap-sync* script we need to create a configuration file describing the various LDAP and Zabbix related config entries:
+In order to use the *zabbix-ldap-sync* script we need to create a configuration file describing the various LDAP and Zabbix related config entries.
+### Config file sections
 
-	[ldap]
-	uri = ldaps://ldap.example.org:636/
-	base = dc=example,dc=org
-	binduser = DOMAIN\ldapuser
-	bindpass = ldappass
-	groups = sysadmins
+#### [ldap]
+* `uri` - URI of the LDAP server, including port
+* `base` - Base `Distinguished Name`.
+* `binduser` - LDAP user which has permissions to perform LDAP search
+* `bindpass` - Password for LDAP user
+* `groups` - LDAP groups to sync with Zabbix
+* `media` - Name of the LDAP attribute of user object, that will be used to set `Send to` property of Zabbix user media. This entry is optional, default value is `mail`.
 
+#### [zabbix]
+* `server` - Zabbix URL
+* `username` - Zabbix username. This user must have permissions to add/remove users and groups. Typically, this would be `Zabbix Admin` account.
+* `password` - Password for Zabbix user
+
+#### [user]
+Allows to override various properties for Zabbix users created by script. See [User object](https://www.zabbix.com/documentation/3.2/manual/api/reference/user/object) in Zabbix API documentation for available properties. If section/property doesn't exist, defaults are:
+
+* `type = 1` - user type (`Zabbix user`) 
+
+#### [media]
+Allows to override media type (`Email`, `Jabber`, `SMS`, etc...) and various properties for Zabbix media for users created by script.
+
+* `decription` - Description of Zabbix media (`Email`, `Jabber`, `SMS`, etc...). This entry is optional, default value is `Email`.
+
+You can configure additional properties in this section. See [Media object](https://www.zabbix.com/documentation/3.2/manual/api/reference/usermedia/object#media) in Zabbix API documentation for available properties. If this section/property doesn't exist, defaults fro additional properties are:
+
+* `active = 0` - Whether the media is enabled. Possible values: `0`- enabled; `1` - disabled.
+* `period =` 1-7,00:00-24:00` - Time when the notifications can be sent as a [time period](https://www.zabbix.com/documentation/3.2/manual/appendix/time_period).
+* `severity = 63` - Decimal value of trigger severities to send notifications about. Each severity value occupies a position of a 6-bit value. Use this table to calculate decimal representation:
+
+```
+╔═════════════╦════════╦════╦═══════╦═══════╦═══════════╦══════════════╗
+║  Severity   ║Disaster║High║Average║Warning║Information║Not Classified║
+╠═════════════╬════════╬════╬═══════╬═══════╬═══════════╬══════════════╣
+║  Enabled ?  ║      1 ║  1 ║     1 ║     1 ║         1 ║            1 ║
+╠═════════════╬════════╩════╩═══════╩═══════╩═══════════╩══════════════╣
+║Decimal value║                     111111 = 63                        ║
+╚═════════════╩════════════════════════════════════════════════════════╝
+```
+
+## Configuration file example
+
+    [ldap]
+    type = activedirectory
+    uri = ldaps://ldap.example.org:389/
+    base = dc=example,dc=org
+    binduser = DOMAIN\ldapuser
+    bindpass = ldappass
+    groups = sysadmins
+    media = mail
+    
+    [zabbix]
+    server = http://zabbix.example.org/zabbix/
+    username = admin
+    password = adminp4ssw0rd
+    
     [user]
-    type = 1
+    type = 3
+    url = http://zabbix.example.org/zabbix/hostinventories.php
+    autologin = 1
+    
+    [media]
+    description = 'Email'
+    active = 0
+    period = 1-5,07:00-22:00
+    severity = 63
 
-	[zabbix]
-	server = http://zabbix.example.org/zabbix/
-	username = admin
-	password = adminp4ssw0rd
-
-`[user]` section is optional. It can be used to set custom properties for Zabbix user created by script. See [User object](https://www.zabbix.com/documentation/3.2/manual/api/reference/user/object) in Zabbix API documentation for available properties.
 
 ## Command-line arguments
 
-    Usage: zabbix-ldap-sync [-ls] -f <config>
+    Usage: zabbix-ldap-sync [-ldsn] -f <config>
            zabbix-ldap-sync -v
            zabbix-ldap-sync -h
     
@@ -48,6 +99,8 @@ In order to use the *zabbix-ldap-sync* script we need to create a configuration 
       -v, --version                 Display version and exit
       -l, --lowercase               Create AD user names as lowercase
       -s, --skip-disabled           Skip disabled AD users
+      -d, --delete-orphans          Delete Zabbix users that don't exist in a LDAP group
+      -n, --no-check-certificate    Don't check Zabbix server certificate
       -f <config>, --file <config>  Configuration file to use
 
 ## Importing LDAP users into Zabbix
@@ -58,4 +111,9 @@ Now that we have the above mentioned configuration file created, let's import ou
 	
 Once the script completes, check your Zabbix Frontend to verify that users are successfully imported.
 
-You would generally be running the above script on regular basis, say each day from `cron(8)` in order to make sure your Zabbix system is in sync with LDAP.
+To sync different LDAP groups with different options, create separate config file for each group and run `zabbix-ldap-sync`:
+
+	$ zabbix-ldap-sync -f /path/to/zabbix-ldap-admins.conf
+	$ zabbix-ldap-sync -f /path/to/zabbix-ldap-users.conf
+
+You would generally be running the above scripts on regular basis, say each day from `cron(8)` in order to make sure your Zabbix system is in sync with LDAP.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ In order to use the *zabbix-ldap-sync* script we need to create a configuration 
 
 #### [ldap]
 * `uri` - URI of the LDAP server, including port
-* `base` - Base `Distinguished Name`.
+* `base` - Base `Distinguished Name`
 * `binduser` - LDAP user which has permissions to perform LDAP search
 * `bindpass` - Password for LDAP user
 * `groups` - LDAP groups to sync with Zabbix
@@ -37,10 +37,10 @@ In order to use the *zabbix-ldap-sync* script we need to create a configuration 
 #### [user]
 Allows to override various properties for Zabbix users created by script. See [User object](https://www.zabbix.com/documentation/3.2/manual/api/reference/user/object) in Zabbix API documentation for available properties. If section/property doesn't exist, defaults are:
 
-* `type = 1` - user type (`Zabbix user`) 
+ * `type = 1` - User type. Possible values: `1` - (default) Zabbix user; `2` - Zabbix admin; `3` - Zabbix super admin. 
 
 #### [media]
-Allows to override media type (`Email`, `Jabber`, `SMS`, etc...) and various properties for Zabbix media for users created by script.
+Allows to override media type and various properties for Zabbix media for users created by script.
 
 * `decription` - Description of Zabbix media (`Email`, `Jabber`, `SMS`, etc...). This entry is optional, default value is `Email`.
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ In order to use the *zabbix-ldap-sync* script we need to create a configuration 
 	[ldap]
 	uri = ldaps://ldap.example.org:636/
 	base = dc=example,dc=org
+	binduser = DOMAIN\ldapuser
+	bindpass = ldappass
 	groups = sysadmins
 
 	[zabbix]

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Allows to override media type (`Email`, `Jabber`, `SMS`, etc...) and various pro
 You can configure additional properties in this section. See [Media object](https://www.zabbix.com/documentation/3.2/manual/api/reference/usermedia/object#media) in Zabbix API documentation for available properties. If this section/property doesn't exist, defaults fro additional properties are:
 
 * `active = 0` - Whether the media is enabled. Possible values: `0`- enabled; `1` - disabled.
-* `period =` 1-7,00:00-24:00` - Time when the notifications can be sent as a [time period](https://www.zabbix.com/documentation/3.2/manual/appendix/time_period).
+* `period = 1-7,00:00-24:00` - Time when the notifications can be sent as a [time period](https://www.zabbix.com/documentation/3.2/manual/appendix/time_period).
 * `severity = 63` - Decimal value of trigger severities to send notifications about. Each severity value occupies a position of a 6-bit value. Use this table to calculate decimal representation:
 
 ```

--- a/zabbix-ldap-sync
+++ b/zabbix-ldap-sync
@@ -517,24 +517,35 @@ class ZabbixLDAPConf(object):
             self.ldap_uri     = parser.get('ldap', 'uri')
             self.ldap_base    = parser.get('ldap', 'base')
             self.ldap_groups  = [i.strip() for i in parser.get('ldap', 'groups').split(',')]
-            self.ldap_type    = parser.get('ldap', 'type')
+
+            try:
+                # Get 'ldap_type' attribute
+                self.ldap_type = parser.get('ldap', 'type')
+            except ConfigParser.NoOptionError:
+                # If not exists, set to None
+                self.ldap_type = None
+
             self.ldap_user    = parser.get('ldap', 'binduser')
             self.ldap_pass    = parser.get('ldap', 'bindpass')
+
             try:
                 # Get 'mail' attribute
                 self.ldap_mail = parser.get('ldap', 'mail')
             except ConfigParser.NoOptionError:
                 # If not exists, set default 'mail' attribute
                 self.ldap_mail = 'mail'
+
             self.zbx_server   = parser.get('zabbix', 'server')
             self.zbx_username = parser.get('zabbix', 'username')
             self.zbx_password = parser.get('zabbix', 'password')
+
             try:
                 # Get user options
                 self.user_opt = parser.items('user')
             except ConfigParser.NoSectionError:
                 # If not exists, set to empty list
                 self.user_opt = {}
+
         except ConfigParser.NoOptionError as e:
             raise SystemExit, 'Configuration issues detected in %s' % self.config
 

--- a/zabbix-ldap-sync
+++ b/zabbix-ldap-sync
@@ -489,13 +489,20 @@ class ZabbixLDAPConf(object):
             self.ldap_user    = parser.get('ldap', 'binduser')
             self.ldap_pass    = parser.get('ldap', 'bindpass')
             try:
+                # Get 'mail' attribute
                 self.ldap_mail = parser.get('ldap', 'mail')
-            except ConfigParser.NoOptionError :
+            except ConfigParser.NoOptionError:
+                # If not exists, set default 'mail' attribute
                 self.ldap_mail = 'mail'
             self.zbx_server   = parser.get('zabbix', 'server')
             self.zbx_username = parser.get('zabbix', 'username')
             self.zbx_password = parser.get('zabbix', 'password')
-            self.user_opt = parser.items('user')
+            try:
+                # Get user options
+                self.user_opt = parser.items('user')
+            except ConfigParser.NoSectionError:
+                # If not exists, set to empty list
+                self.user_opt = {}
         except ConfigParser.NoOptionError as e:
             raise SystemExit, 'Configuration issues detected in %s' % self.config
 

--- a/zabbix-ldap-sync
+++ b/zabbix-ldap-sync
@@ -291,6 +291,26 @@ class ZabbixConn(object):
 
         return users
 
+    def get_mediatype_id(self, description):
+        """
+        Retrieves the mediatypeid by description
+
+        Args:
+            description (str): Zabbix media type description
+
+        Returns:
+            The mediatypeid for specified media type description
+
+        """
+        result = self.conn.mediatype.get(filter={'description':description})
+
+        if result:
+            mediatypeid = result[0]['mediatypeid']
+        else:
+            mediatypeid = None
+
+        return mediatypeid
+
     def get_user_id(self, user):
         """
         Retrieves the userid of a specified user
@@ -415,8 +435,12 @@ class ZabbixConn(object):
         """
 
         userid = self.get_user_id(user)
+        mediatypeid = self.get_mediatype_id('Email')
 
-        result = self.conn.user.addmedia(users=[ { "userid": str(userid) } ], medias={ 'mediatypeid': '1', 'sendto': mail, 'active': '0', 'severity': '63', 'period': '1-7,00:00-24:00' })
+        if mediatypeid:
+            result = self.conn.user.addmedia(users=[ { "userid": str(userid) } ], medias={ 'mediatypeid': mediatypeid, 'sendto': mail, 'active': '0', 'severity': '63', 'period': '1-7,00:00-24:00' })
+        else:
+            result = None
 
         return result
 

--- a/zabbix-ldap-sync
+++ b/zabbix-ldap-sync
@@ -60,7 +60,7 @@ class LDAPConn(object):
 
         """
         self.conn  = ldap.initialize(self.uri)
-	self.conn.set_option(ldap.OPT_REFERRALS,0)
+        self.conn.set_option(ldap.OPT_REFERRALS,0)
 
         try:
             self.conn.simple_bind(self.ldap_user, self.ldap_pass)
@@ -100,7 +100,7 @@ class LDAPConn(object):
         # if this is activedirectory, we have to replace each CN with the actual username
         if active_directory:
 
-            final_listing = []
+            final_listing = {}
 
             for members in result:
                 result_dn = members[0]
@@ -110,20 +110,20 @@ class LDAPConn(object):
                 for member in result_attrs["member"]:
 
                     attrlist = ['sAMAccountName']
-                    filter   = '(&(objectClass=person)(distinguishedName=%s))' % ldap.filter.escape_filter_chars(member)
 
                     # get the actual LDAP object for each group member
-                    uid = self.conn.search_s(base=self.base,
-                                    scope=ldap.SCOPE_SUBTREE,
-                                    filterstr=filter,
-                                    attrlist=attrlist)
+                    uid = self.conn.search_s(base = member,
+                                    scope = ldap.SCOPE_BASE,
+                                    attrlist = attrlist)
 
                     dn, users = uid.pop()
                     username = users.get('sAMAccountName')
                     if lowercase:
-                        final_listing.append(str(username)[2 : -2].lower())
+                        username = str(username)[2 : -2].lower()
                     else:
-                        final_listing.append(str(username)[2 : -2])
+                        username = str(username)[2 : -2]
+
+                    final_listing[username] = dn
 
             return final_listing
 
@@ -133,12 +133,12 @@ class LDAPConn(object):
 
             return users[group_member_attribute]
 
-    def get_user_email(self, username, ldap_mail):
+    def get_user_email(self, dn, ldap_mail):
         """
         Retrieves the 'mail' attribute of an LDAP user
 
         Args:
-            username (str): The LDAP username to lookup
+            username (str): The LDAP distinguished name to lookup
             ldap_mail (str): The name of the field containing the mail address
 
         Returns:
@@ -146,12 +146,10 @@ class LDAPConn(object):
 
         """
         attrlist = [ldap_mail]
-        filter   = mail_filter % username
 
-        result = self.conn.search_s(base=self.base,
-                                    scope=ldap.SCOPE_SUBTREE,
-                                    filterstr=filter,
-                                    attrlist=attrlist)
+        result = self.conn.search_s(base = dn,
+                                    scope = ldap.SCOPE_BASE,
+                                    attrlist = attrlist)
 
         if not result:
             return None
@@ -165,23 +163,21 @@ class LDAPConn(object):
 
         return mail.pop()
 
-    def get_user_sn(self, username):
+    def get_user_sn(self, dn):
         """
         Retrieves the 'sn' attribute of an LDAP user
 
         Args:
-            username (str): The LDAP username to lookup
+            username (str): The LDAP distinguished name to lookup
 
         Returns:
             The user's surname attribute
 
         """
         attrlist = ['sn']
-        filter   = sn_filter % username
 
-        result = self.conn.search_s(base=self.base,
-                                    scope=ldap.SCOPE_SUBTREE,
-                                    filterstr=filter,
+        result = self.conn.search_s(base=dn,
+                                    scope=ldap.SCOPE_BASE,
                                     attrlist=attrlist)
 
         if not result:
@@ -196,23 +192,21 @@ class LDAPConn(object):
 
         return sn.pop()
 
-    def get_user_givenName(self, username):
+    def get_user_givenName(self, dn):
         """
         Retrieves the 'givenName' attribute of an LDAP user
 
         Args:
-            username (str): The LDAP username to lookup
+            username (str): The LDAP distinguished name to lookup
 
         Returns:
             The user's given name attribute
 
         """
         attrlist = ['givenName']
-        filter   = givenName_filter % username
 
-        result = self.conn.search_s(base=self.base,
-                                    scope=ldap.SCOPE_SUBTREE,
-                                    filterstr=filter,
+        result = self.conn.search_s(base=dn,
+                                    scope=ldap.SCOPE_BASE,
                                     attrlist=attrlist)
 
         if not result:
@@ -417,7 +411,7 @@ class ZabbixConn(object):
 
             zabbix_group_users = self.get_group_members(zabbix_grpid)
 
-            missing_users = set(ldap_users) - set(zabbix_group_users)
+            missing_users = set(list(ldap_users.keys())) - set(zabbix_group_users)
 
             # Add missing users
             for eachUser in missing_users:
@@ -426,12 +420,12 @@ class ZabbixConn(object):
                 if eachUser not in zabbix_all_users:
                     print '>>> Creating user %s, member of Zabbix group %s' % (eachUser, eachGroup)
                     user = { 'alias': eachUser }
-                    user['name'] = ldap_conn.get_user_givenName(eachUser)
-                    user['surname'] = ldap_conn.get_user_sn(eachUser)
+                    user['name'] = ldap_conn.get_user_givenName(ldap_users[eachUser])
+                    user['surname'] = ldap_conn.get_user_sn(ldap_users[eachUser])
                     self.create_user(user, zabbix_grpid)
                     zabbix_all_users.append(eachUser)
                     print '>>> Updating user media for %s, adding email' % eachUser
-                    mailaddress = ldap_conn.get_user_email(eachUser, ldap_mail)
+                    mailaddress = ldap_conn.get_user_email(ldap_users[eachUser], ldap_mail)
                     if mailaddress:
                         self.update_media(eachUser, mailaddress)
                 else:
@@ -440,7 +434,7 @@ class ZabbixConn(object):
                     self.update_user(eachUser, zabbix_grpid)
 
             # Just mention any extra users in the groups, do not remove them
-            extra_users = set(zabbix_group_users) - set(ldap_users)
+            extra_users = set(zabbix_group_users) - set(list(ldap_users.keys()))
             if extra_users:
                 print '>>> Users in group %s which are not found in LDAP group:' % eachGroup
                 for eachUser in extra_users:
@@ -516,10 +510,9 @@ Options:
         group_filter = "(&(objectClass=group)(name=%s))"
         group_member_attribute = "member"
         uid_attribute = "sAMAccountName"
-        sn_filter = "(&(objectClass=person)(sAMAccountName=%s))"
-        givenName_filter = "(&(objectClass=person)(sAMAccountName=%s))"
-        mail_filter = "(&(objectClass=person)(sAMAccountName=%s))"
     else:
+        # Remove once someone figures out how to get DN's from LDAP
+        raise SystemExit, 'Only "activedirectory" type is supported in this version!'
         active_directory = None
         group_filter = "(&(objectClass=posixGroup)(cn=%s))"
         group_member_attribute = "memberUid"

--- a/zabbix-ldap-sync
+++ b/zabbix-ldap-sync
@@ -659,7 +659,6 @@ Options:
     global lowercase
     global skipdisabled
     global deleteorphans
-    global nocheckcertificate
     lowercase = args['--lowercase']
     skipdisabled = args['--skip-disabled']
     deleteorphans = args['--delete-orphans']

--- a/zabbix-ldap-sync
+++ b/zabbix-ldap-sync
@@ -108,22 +108,29 @@ class LDAPConn(object):
 
             if "member" in result_attrs:
                 for member in result_attrs["member"]:
-
                     attrlist = [uid_attribute]
 
                     # get the actual LDAP object for each group member
-                    uid = self.conn.search_s(base = member,
-                                    scope = ldap.SCOPE_BASE,
-                                    attrlist = attrlist)
-
-                    dn, users = uid.pop()
-                    username = users.get(uid_attribute)
-                    if lowercase:
-                        username = str(username)[2 : -2].lower()
+                    if skipdisabled:
+                        uid = self.conn.search_s(base = member,
+                                        scope = ldap.SCOPE_BASE,
+                                        filterstr = disabled_filter,
+                                        attrlist = attrlist)
                     else:
-                        username = str(username)[2 : -2]
+                        uid = self.conn.search_s(base = member,
+                                        scope = ldap.SCOPE_BASE,
+                                        attrlist = attrlist)
 
-                    final_listing[username] = dn
+                    if uid:
+                        dn, users = uid.pop()
+                        username = users.get(uid_attribute)
+
+                        if lowercase:
+                            username = str(username)[2 : -2].lower()
+                        else:
+                            username = str(username)[2 : -2]
+
+                        final_listing[username] = dn
 
             return final_listing
 
@@ -477,7 +484,6 @@ class ZabbixLDAPConf(object):
             ConfigParser.NoOptionError
 
         """
-        #parser = ConfigParser.ConfigParser({"mail": "mail"})
         parser = ConfigParser.ConfigParser()
         parser.read(self.config)
 
@@ -508,7 +514,7 @@ class ZabbixLDAPConf(object):
 
 def main():
     usage="""
-Usage: zabbix-ldap-sync [-l] -f <config>
+Usage: zabbix-ldap-sync [-ls] -f <config>
        zabbix-ldap-sync -v
        zabbix-ldap-sync -h
 
@@ -516,6 +522,7 @@ Options:
   -h, --help                    Display this usage info
   -v, --version                 Display version and exit
   -l, --lowercase               Create AD user names as lowercase
+  -s, --skip-disabled           Skip disabled AD users
   -f <config>, --file <config>  Configuration file to use
 
 """
@@ -527,6 +534,7 @@ Options:
     # set up AD differences, if necessary
     global active_directory
     global group_filter
+    global disabled_filter
     global group_member_attribute
     global uid_attribute
     global dn_filter
@@ -534,10 +542,13 @@ Options:
     global givenName_filter
     global mail_filter
     global lowercase
+    global skipdisabled
     lowercase = args['--lowercase']
+    skipdisabled = args['--skip-disabled']
     if config.ldap_type == 'activedirectory':
         active_directory = "true"
         group_filter = "(&(objectClass=group)(name=%s))"
+        disabled_filter="(!(userAccountControl:1.2.840.113556.1.4.803:=2))"
         group_member_attribute = "member"
         uid_attribute = "sAMAccountName"
     else:

--- a/zabbix-ldap-sync
+++ b/zabbix-ldap-sync
@@ -156,19 +156,19 @@ class LDAPConn(object):
             
             return final_listing
 
-    def get_user_email(self, dn, ldap_mail):
+    def get_user_media(self, dn, ldap_media):
         """
         Retrieves the 'mail' attribute of an LDAP user
 
         Args:
             username (str): The LDAP distinguished name to lookup
-            ldap_mail (str): The name of the field containing the mail address
+            ldap_media (str): The name of the field containing the media address
 
         Returns:
             The user's mail attribute
 
         """
-        attrlist = [ldap_mail]
+        attrlist = [ldap_media]
 
         result = self.conn.search_s(base = dn,
                                     scope = ldap.SCOPE_BASE,
@@ -179,7 +179,7 @@ class LDAPConn(object):
 
         dn, data = result.pop()
 
-        mail = data.get(ldap_mail)
+        mail = data.get(ldap_media)
 
         if not mail:
             return None
@@ -382,8 +382,9 @@ class ZabbixConn(object):
         Creates a new Zabbix user
 
         Args:
-            user    (dict): A dict containing the user details
-            groupid  (int): The groupid for the new user
+            user     (dict): A dict containing the user details
+            groupid   (int): The groupid for the new user
+            user_opt (dict): User options
 
         """
         random_passwd = ''.join(random.sample(string.ascii_letters + string.digits, 32))
@@ -425,20 +426,26 @@ class ZabbixConn(object):
 
         return result
 
-    def update_media(self, user, mail):
+    def update_media(self, user, description, sendto, media_opt):
         """
-        Adds media (email) to an existing Zabbix user
+        Adds media to an existing Zabbix user
 
         Args:
-            user    (dict): A dict containing the user details
+            user        (dict): A dict containing the user details
+            description  (str): A string containing Zabbix media description
+            sendto       (str): A string containing address, phone number, etc...
+            media_opt    (dict): Media options
 
         """
 
         userid = self.get_user_id(user)
-        mediatypeid = self.get_mediatype_id('Email')
+        mediatypeid = self.get_mediatype_id(description)
 
         if mediatypeid:
-            result = self.conn.user.addmedia(users=[ { "userid": str(userid) } ], medias={ 'mediatypeid': mediatypeid, 'sendto': mail, 'active': '0', 'severity': '63', 'period': '1-7,00:00-24:00' })
+            media_defaults = { 'mediatypeid': mediatypeid, 'sendto': sendto , 'active': '0', 'severity': '63', 'period': '1-7,00:00-24:00' }
+            media_defaults.update(media_opt)
+
+            result = self.conn.user.addmedia(users=[ { "userid": str(userid) } ], medias = media_defaults)
         else:
             result = None
 
@@ -459,7 +466,7 @@ class ZabbixConn(object):
             grpid = self.create_group(eachGroup)
             print '>>> Group %s created with groupid %s' % (eachGroup, grpid)
 
-    def sync_users(self, ldap_uri, ldap_base, ldap_groups, ldap_user, ldap_pass, ldap_mail, zabbix_user_opt):
+    def sync_users(self, ldap_uri, ldap_base, ldap_groups, ldap_user, ldap_pass, ldap_media, user_opt, media_description, media_opt):
         """
         Syncs Zabbix with LDAP users
 
@@ -491,12 +498,12 @@ class ZabbixConn(object):
                     user = { 'alias': eachUser }
                     user['name'] = ldap_conn.get_user_givenName(ldap_users[eachUser])
                     user['surname'] = ldap_conn.get_user_sn(ldap_users[eachUser])
-                    self.create_user(user, zabbix_grpid, zabbix_user_opt)
+                    self.create_user(user, zabbix_grpid, user_opt)
                     zabbix_all_users.append(eachUser)
-                    print '>>> Updating user media for %s, adding email' % eachUser
-                    mailaddress = ldap_conn.get_user_email(ldap_users[eachUser], ldap_mail)
-                    if mailaddress:
-                        self.update_media(eachUser, mailaddress)
+                    print '>>> Updating user media for %s, adding %s' % (eachUser, media_description)
+                    sendto = ldap_conn.get_user_media(ldap_users[eachUser], ldap_media)
+                    if sendto:
+                        self.update_media(eachUser, media_description, sendto, media_opt)
                 else:
                     # Update existing user to be member of the group
                     print '>>> Updating user %s, adding to group %s' % (eachUser, eachGroup)
@@ -526,6 +533,64 @@ class ZabbixLDAPConf(object):
     def __init__(self, config):
         self.config = config
 
+    def try_get_item(self, parser, section, option, default):
+        """
+        Gets config item
+
+        Args:
+            parser  (ConfigParser): ConfigParser
+            section          (str): Config section name
+            option           (str): Config option name
+            default               : Value to return if item doesn't exist
+
+        Returns:
+            Config item value or default value
+
+        """
+
+        try:
+            result = parser.get(section, option)
+        except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
+            result = default
+
+        return result
+
+    def try_get_section(self, parser, section, default):
+        """
+        Gets config section
+
+        Args:
+            parser  (ConfigParser): ConfigParser
+            section          (str): Config section name
+            default               : Value to return if section doesn't exist
+
+        Returns:
+            Config section dict or default value
+
+        """
+
+        try:
+            result = parser.items(section)
+        except ConfigParser.NoSectionError:
+            result = default
+
+        return result
+
+    def remove_config_section_items(self, section, items):
+        """
+        Removes items from config section
+
+        Args:
+            section     (dict of tuples): Config section
+            items                 (list): Item names to remove
+
+        Returns:
+            Config section without specified items
+
+        """
+
+        return [i for i in section if i[0] not in items]
+
     def load_config(self):
         """
         Loads the configuration file
@@ -538,37 +603,27 @@ class ZabbixLDAPConf(object):
         parser.read(self.config)
 
         try:
-            self.ldap_uri     = parser.get('ldap', 'uri')
-            self.ldap_base    = parser.get('ldap', 'base')
-            self.ldap_groups  = [i.strip() for i in parser.get('ldap', 'groups').split(',')]
+            self.ldap_type        = self.try_get_item(parser, 'ldap', 'type', None)
 
-            try:
-                # Get 'ldap_type' attribute
-                self.ldap_type = parser.get('ldap', 'type')
-            except ConfigParser.NoOptionError:
-                # If not exists, set to None
-                self.ldap_type = None
+            self.ldap_uri         = parser.get('ldap', 'uri')
+            self.ldap_base        = parser.get('ldap', 'base')
 
-            self.ldap_user    = parser.get('ldap', 'binduser')
-            self.ldap_pass    = parser.get('ldap', 'bindpass')
+            self.ldap_groups      = [i.strip() for i in parser.get('ldap', 'groups').split(',')]
 
-            try:
-                # Get 'mail' attribute
-                self.ldap_mail = parser.get('ldap', 'mail')
-            except ConfigParser.NoOptionError:
-                # If not exists, set default 'mail' attribute
-                self.ldap_mail = 'mail'
+            self.ldap_user        = parser.get('ldap', 'binduser')
+            self.ldap_pass        = parser.get('ldap', 'bindpass')
 
-            self.zbx_server   = parser.get('zabbix', 'server')
-            self.zbx_username = parser.get('zabbix', 'username')
-            self.zbx_password = parser.get('zabbix', 'password')
+            self.ldap_media       = self.try_get_item(parser, 'ldap', 'media', 'mail')
 
-            try:
-                # Get user options
-                self.user_opt = parser.items('user')
-            except ConfigParser.NoSectionError:
-                # If not exists, set to empty list
-                self.user_opt = {}
+            self.zbx_server       = parser.get('zabbix', 'server')
+            self.zbx_username     = parser.get('zabbix', 'username')
+            self.zbx_password     = parser.get('zabbix', 'password')
+
+            self.user_opt         = self.try_get_section(parser, 'user', {})
+
+            self.media_desciption = self.try_get_item(parser, 'media', 'desciption', 'Email')
+            self.media_opt        = self.remove_config_section_items(self.try_get_section(parser, 'media', {}),
+                                                   ('description', 'userid'))
 
         except ConfigParser.NoOptionError as e:
             raise SystemExit, 'Configuration issues detected in %s' % self.config
@@ -624,7 +679,15 @@ Options:
     zabbix_conn.connect(nocheckcertificate)
 
     zabbix_conn.create_missing_groups(config.ldap_groups)
-    zabbix_conn.sync_users(config.ldap_uri, config.ldap_base, config.ldap_groups, config.ldap_user, config.ldap_pass, config.ldap_mail, config.user_opt)
+    zabbix_conn.sync_users(config.ldap_uri,
+                           config.ldap_base,
+                           config.ldap_groups,
+                           config.ldap_user,
+                           config.ldap_pass,
+                           config.ldap_media,
+                           config.user_opt,
+                           config.media_desciption,
+                           config.media_opt)
 
 if __name__ == '__main__':
     main()

--- a/zabbix-ldap-sync
+++ b/zabbix-ldap-sync
@@ -328,7 +328,7 @@ class ZabbixConn(object):
 
         return groupid
 
-    def create_user(self, user, groupid):
+    def create_user(self, user, groupid, user_opt):
         """
         Creates a new Zabbix user
 
@@ -339,7 +339,8 @@ class ZabbixConn(object):
         """
         random_passwd = ''.join(random.sample(string.ascii_letters + string.digits, 32))
 
-        user_defaults = { 'autologin': 0, 'type': 1, 'usrgrps': [ { 'usrgrpid': str(groupid) } ], 'passwd': random_passwd}
+        user_defaults = {'autologin': 0, 'type': 1, 'usrgrps': [ { 'usrgrpid': str(groupid) } ], 'passwd': random_passwd}
+        user_defaults.update(user_opt)
         user.update(user_defaults)
 
         result = self.conn.user.create(user)
@@ -391,7 +392,7 @@ class ZabbixConn(object):
             grpid = self.create_group(eachGroup)
             print '>>> Group %s created with groupid %s' % (eachGroup, grpid)
 
-    def sync_users(self, ldap_uri, ldap_base, ldap_groups, ldap_user, ldap_pass, ldap_mail):
+    def sync_users(self, ldap_uri, ldap_base, ldap_groups, ldap_user, ldap_pass, ldap_mail, zabbix_user_opt):
         """
         Syncs Zabbix with LDAP users
 
@@ -422,7 +423,7 @@ class ZabbixConn(object):
                     user = { 'alias': eachUser }
                     user['name'] = ldap_conn.get_user_givenName(ldap_users[eachUser])
                     user['surname'] = ldap_conn.get_user_sn(ldap_users[eachUser])
-                    self.create_user(user, zabbix_grpid)
+                    self.create_user(user, zabbix_grpid, zabbix_user_opt)
                     zabbix_all_users.append(eachUser)
                     print '>>> Updating user media for %s, adding email' % eachUser
                     mailaddress = ldap_conn.get_user_email(ldap_users[eachUser], ldap_mail)
@@ -472,12 +473,13 @@ class ZabbixLDAPConf(object):
             self.ldap_user    = parser.get('ldap', 'binduser')
             self.ldap_pass    = parser.get('ldap', 'bindpass')
             try:
-                self.ldap_mail    = parser.get('ldap', 'mail')
+                self.ldap_mail = parser.get('ldap', 'mail')
             except ConfigParser.NoOptionError :
-                self.ldap_mail - 'mail'
+                self.ldap_mail = 'mail'
             self.zbx_server   = parser.get('zabbix', 'server')
             self.zbx_username = parser.get('zabbix', 'username')
             self.zbx_password = parser.get('zabbix', 'password')
+            self.user_opt = parser.items('user')
         except ConfigParser.NoOptionError as e:
             raise SystemExit, 'Configuration issues detected in %s' % self.config
 
@@ -527,7 +529,7 @@ Options:
     zabbix_conn.connect()
 
     zabbix_conn.create_missing_groups(config.ldap_groups)
-    zabbix_conn.sync_users(config.ldap_uri, config.ldap_base, config.ldap_groups, config.ldap_user, config.ldap_pass, config.ldap_mail)
+    zabbix_conn.sync_users(config.ldap_uri, config.ldap_base, config.ldap_groups, config.ldap_user, config.ldap_pass, config.ldap_mail, config.user_opt)
 
 if __name__ == '__main__':
     main()

--- a/zabbix-ldap-sync
+++ b/zabbix-ldap-sync
@@ -460,7 +460,8 @@ class ZabbixLDAPConf(object):
             ConfigParser.NoOptionError
 
         """
-        parser = ConfigParser.ConfigParser({"mail": "mail"})
+        #parser = ConfigParser.ConfigParser({"mail": "mail"})
+        parser = ConfigParser.ConfigParser()
         parser.read(self.config)
 
         try:
@@ -470,7 +471,10 @@ class ZabbixLDAPConf(object):
             self.ldap_type    = parser.get('ldap', 'type')
             self.ldap_user    = parser.get('ldap', 'binduser')
             self.ldap_pass    = parser.get('ldap', 'bindpass')
-            self.ldap_mail    = parser.get('ldap', 'mail')
+            try:
+                self.ldap_mail    = parser.get('ldap', 'mail')
+            except ConfigParser.NoOptionError :
+                self.ldap_mail - 'mail'
             self.zbx_server   = parser.get('zabbix', 'server')
             self.zbx_username = parser.get('zabbix', 'username')
             self.zbx_password = parser.get('zabbix', 'password')

--- a/zabbix-ldap-sync
+++ b/zabbix-ldap-sync
@@ -581,7 +581,7 @@ class ZabbixLDAPConf(object):
         Removes items from config section
 
         Args:
-            section     (dict of tuples): Config section
+            section     (list of tuples): Config section
             items                 (list): Item names to remove
 
         Returns:

--- a/zabbix-ldap-sync
+++ b/zabbix-ldap-sync
@@ -97,7 +97,7 @@ class LDAPConn(object):
             print '>>> Unable to find group %s, skipping group' % group
             return None
 
-        # if this is activedirectory, we have to replace each CN with the actual username
+        # Get DN for each user in the group
         if active_directory:
 
             final_listing = {}
@@ -130,8 +130,24 @@ class LDAPConn(object):
         else:
 
             dn, users = result.pop()
+            
+            final_listing = {}
 
-            return users[group_member_attribute]
+            # Get DN for each user in the group
+            for uid in users[group_member_attribute]:
+                filter = dn_filter % uid
+                attrlist = ['']
+
+                # get the actual LDAP object for each group member
+                user = self.conn.search_s(base = self.base,
+                                    scope = ldap.SCOPE_SUBTREE,
+                                    filterstr = filter,
+                                    attrlist = attrlist)
+
+                for items in user:
+                    final_listing[uid] = items[0]
+            
+            return final_listing
 
     def get_user_email(self, dn, ldap_mail):
         """
@@ -506,6 +522,7 @@ Options:
     global group_filter
     global group_member_attribute
     global uid_attribute
+    global dn_filter
     global sn_filter
     global givenName_filter
     global mail_filter
@@ -517,11 +534,10 @@ Options:
         group_member_attribute = "member"
         uid_attribute = "sAMAccountName"
     else:
-        # Remove once someone figures out how to get DN's from LDAP
-        raise SystemExit, 'Only "activedirectory" type is supported in this version!'
         active_directory = None
         group_filter = "(&(objectClass=posixGroup)(cn=%s))"
         group_member_attribute = "memberUid"
+        dn_filter = "(&(objectClass=posixAccount)(uid=%s))"
         sn_filter = "(&(objectClass=posixAccount)(uid=%s))"
         givenName_filter = "(&(objectClass=posixAccount)(uid=%s))"
         mail_filter = "(&(objectClass=posixAccount)(uid=%s))"

--- a/zabbix-ldap-sync
+++ b/zabbix-ldap-sync
@@ -370,6 +370,20 @@ class ZabbixConn(object):
 
         return result
 
+    def delete_user(self, user):
+        """
+        Deletes Zabbix user
+
+        Args:
+            user (string): Zabbix username
+
+        """
+        userid = self.get_user_id(user)
+
+        result = self.conn.user.delete(userid)
+
+        return result
+
     def update_user(self, user, groupid):
         """
         Adds an existing Zabbix user to a group
@@ -428,7 +442,8 @@ class ZabbixConn(object):
         for eachGroup in ldap_groups:
             ldap_users = ldap_conn.get_group_members(eachGroup)
 
-            if not ldap_users:
+            # Do nothing if LDAP group contains no users and "--delete-orphans" is not specified
+            if not ldap_users and not deleteorphans:
                 continue
 
             zabbix_grpid = [g['usrgrpid'] for g in self.get_groups() if g['name'] == eachGroup].pop()
@@ -457,12 +472,17 @@ class ZabbixConn(object):
                     print '>>> Updating user %s, adding to group %s' % (eachUser, eachGroup)
                     self.update_user(eachUser, zabbix_grpid)
 
-            # Just mention any extra users in the groups, do not remove them
+            # Handle any extra users in the groups
             extra_users = set(zabbix_group_users) - set(list(ldap_users.keys()))
             if extra_users:
                 print '>>> Users in group %s which are not found in LDAP group:' % eachGroup
+
                 for eachUser in extra_users:
-                    print ' * %s' % eachUser
+                    if deleteorphans:
+                        print 'Deleting user: %s' % eachUser
+                        self.delete_user(eachUser)
+                    else:
+                        print ' * %s' % eachUser
 
         ldap_conn.disconnect()
 
@@ -514,7 +534,7 @@ class ZabbixLDAPConf(object):
 
 def main():
     usage="""
-Usage: zabbix-ldap-sync [-ls] -f <config>
+Usage: zabbix-ldap-sync [-lds] -f <config>
        zabbix-ldap-sync -v
        zabbix-ldap-sync -h
 
@@ -523,6 +543,7 @@ Options:
   -v, --version                 Display version and exit
   -l, --lowercase               Create AD user names as lowercase
   -s, --skip-disabled           Skip disabled AD users
+  -d, --delete-orphans          Delete Zabbix users that don't exist in a LDAP group
   -f <config>, --file <config>  Configuration file to use
 
 """
@@ -540,8 +561,10 @@ Options:
     global dn_filter
     global lowercase
     global skipdisabled
+    global deleteorphans
     lowercase = args['--lowercase']
     skipdisabled = args['--skip-disabled']
+    deleteorphans = args['--delete-orphans']
     if config.ldap_type == 'activedirectory':
         active_directory = "true"
         group_filter = "(&(objectClass=group)(name=%s))"

--- a/zabbix-ldap-sync
+++ b/zabbix-ldap-sync
@@ -538,9 +538,6 @@ Options:
     global group_member_attribute
     global uid_attribute
     global dn_filter
-    global sn_filter
-    global givenName_filter
-    global mail_filter
     global lowercase
     global skipdisabled
     lowercase = args['--lowercase']
@@ -556,9 +553,6 @@ Options:
         group_filter = "(&(objectClass=posixGroup)(cn=%s))"
         group_member_attribute = "memberUid"
         dn_filter = "(&(objectClass=posixAccount)(uid=%s))"
-        sn_filter = "(&(objectClass=posixAccount)(uid=%s))"
-        givenName_filter = "(&(objectClass=posixAccount)(uid=%s))"
-        mail_filter = "(&(objectClass=posixAccount)(uid=%s))"
     zabbix_conn = ZabbixConn(config.zbx_server, config.zbx_username, config.zbx_password)
     zabbix_conn.connect()
 

--- a/zabbix-ldap-sync
+++ b/zabbix-ldap-sync
@@ -256,14 +256,20 @@ class ZabbixConn(object):
         self.username = username
         self.password = password
 
-    def connect(self):
+    def connect(self, nocheckcertificate):
         """
         Establishes a connection to the Zabbix server
+
+        Args:
+            nocheckcertificate (bool): Don't check the server certificate
 
         Raises:
             SystemExit
 
         """
+        if nocheckcertificate:
+            self.conn.session.verify = False
+
         self.conn = ZabbixAPI(self.server)
 
         try:
@@ -534,7 +540,7 @@ class ZabbixLDAPConf(object):
 
 def main():
     usage="""
-Usage: zabbix-ldap-sync [-lds] -f <config>
+Usage: zabbix-ldap-sync [-ldsn] -f <config>
        zabbix-ldap-sync -v
        zabbix-ldap-sync -h
 
@@ -544,6 +550,7 @@ Options:
   -l, --lowercase               Create AD user names as lowercase
   -s, --skip-disabled           Skip disabled AD users
   -d, --delete-orphans          Delete Zabbix users that don't exist in a LDAP group
+  -n, --no-check-certificate    Don't check Zabbix server certificate
   -f <config>, --file <config>  Configuration file to use
 
 """
@@ -562,9 +569,11 @@ Options:
     global lowercase
     global skipdisabled
     global deleteorphans
+    global nocheckcertificate
     lowercase = args['--lowercase']
     skipdisabled = args['--skip-disabled']
     deleteorphans = args['--delete-orphans']
+    nocheckcertificate = args['--no-check-certificate']
     if config.ldap_type == 'activedirectory':
         active_directory = "true"
         group_filter = "(&(objectClass=group)(name=%s))"
@@ -577,7 +586,7 @@ Options:
         group_member_attribute = "memberUid"
         dn_filter = "(&(objectClass=posixAccount)(uid=%s))"
     zabbix_conn = ZabbixConn(config.zbx_server, config.zbx_username, config.zbx_password)
-    zabbix_conn.connect()
+    zabbix_conn.connect(nocheckcertificate)
 
     zabbix_conn.create_missing_groups(config.ldap_groups)
     zabbix_conn.sync_users(config.ldap_uri, config.ldap_base, config.ldap_groups, config.ldap_user, config.ldap_pass, config.ldap_mail, config.user_opt)

--- a/zabbix-ldap-sync
+++ b/zabbix-ldap-sync
@@ -109,7 +109,7 @@ class LDAPConn(object):
             if "member" in result_attrs:
                 for member in result_attrs["member"]:
 
-                    attrlist = ['sAMAccountName']
+                    attrlist = [uid_attribute]
 
                     # get the actual LDAP object for each group member
                     uid = self.conn.search_s(base = member,
@@ -117,7 +117,7 @@ class LDAPConn(object):
                                     attrlist = attrlist)
 
                     dn, users = uid.pop()
-                    username = users.get('sAMAccountName')
+                    username = users.get(uid_attribute)
                     if lowercase:
                         username = str(username)[2 : -2].lower()
                     else:

--- a/zabbix-ldap-sync
+++ b/zabbix-ldap-sync
@@ -38,6 +38,7 @@ import ldap.filter
 from pyzabbix import ZabbixAPI
 from docopt import docopt
 
+
 class LDAPConn(object):
     """
     LDAP connector class
@@ -45,11 +46,12 @@ class LDAPConn(object):
     Defines methods for retrieving users and groups from LDAP server.
 
     """
+
     def __init__(self, uri, base, user, passwd):
-        self.uri   = uri
-        self.base  = base
-        self.ldap_user  = user
-        self.ldap_pass  = passwd
+        self.uri = uri
+        self.base = base
+        self.ldap_user = user
+        self.ldap_pass = passwd
 
     def connect(self):
         """
@@ -59,13 +61,13 @@ class LDAPConn(object):
             SystemExit
 
         """
-        self.conn  = ldap.initialize(self.uri)
-        self.conn.set_option(ldap.OPT_REFERRALS,0)
+        self.conn = ldap.initialize(self.uri)
+        self.conn.set_option(ldap.OPT_REFERRALS, 0)
 
         try:
             self.conn.simple_bind(self.ldap_user, self.ldap_pass)
         except ldap.SERVER_DOWN as e:
-            raise SystemExit, 'Cannot connect to LDAP server: %s' % e
+            raise SystemExit('Cannot connect to LDAP server: %s' % e)
 
     def disconnect(self):
         """
@@ -86,7 +88,7 @@ class LDAPConn(object):
 
         """
         attrlist = [group_member_attribute]
-        filter   = group_filter % group
+        filter = group_filter % group
 
         result = self.conn.search_s(base=self.base,
                                     scope=ldap.SCOPE_SUBTREE,
@@ -112,23 +114,23 @@ class LDAPConn(object):
 
                     # get the actual LDAP object for each group member
                     if skipdisabled:
-                        uid = self.conn.search_s(base = member,
-                                        scope = ldap.SCOPE_BASE,
-                                        filterstr = disabled_filter,
-                                        attrlist = attrlist)
+                        uid = self.conn.search_s(base=member,
+                                                 scope=ldap.SCOPE_BASE,
+                                                 filterstr=disabled_filter,
+                                                 attrlist=attrlist)
                     else:
-                        uid = self.conn.search_s(base = member,
-                                        scope = ldap.SCOPE_BASE,
-                                        attrlist = attrlist)
+                        uid = self.conn.search_s(base=member,
+                                                 scope=ldap.SCOPE_BASE,
+                                                 attrlist=attrlist)
 
                     if uid:
                         dn, users = uid.pop()
                         username = users.get(uid_attribute)
 
                         if lowercase:
-                            username = str(username)[2 : -2].lower()
+                            username = str(username)[2: -2].lower()
                         else:
-                            username = str(username)[2 : -2]
+                            username = str(username)[2: -2]
 
                         final_listing[username] = dn
 
@@ -137,7 +139,7 @@ class LDAPConn(object):
         else:
 
             dn, users = result.pop()
-            
+
             final_listing = {}
 
             # Get DN for each user in the group
@@ -146,14 +148,14 @@ class LDAPConn(object):
                 attrlist = ['']
 
                 # get the actual LDAP object for each group member
-                user = self.conn.search_s(base = self.base,
-                                    scope = ldap.SCOPE_SUBTREE,
-                                    filterstr = filter,
-                                    attrlist = attrlist)
+                user = self.conn.search_s(base=self.base,
+                                          scope=ldap.SCOPE_SUBTREE,
+                                          filterstr=filter,
+                                          attrlist=attrlist)
 
                 for items in user:
                     final_listing[uid] = items[0]
-            
+
             return final_listing
 
     def get_user_media(self, dn, ldap_media):
@@ -170,9 +172,9 @@ class LDAPConn(object):
         """
         attrlist = [ldap_media]
 
-        result = self.conn.search_s(base = dn,
-                                    scope = ldap.SCOPE_BASE,
-                                    attrlist = attrlist)
+        result = self.conn.search_s(base=dn,
+                                    scope=ldap.SCOPE_BASE,
+                                    attrlist=attrlist)
 
         if not result:
             return None
@@ -244,6 +246,7 @@ class LDAPConn(object):
 
         return name.pop()
 
+
 class ZabbixConn(object):
     """
     Zabbix connector class
@@ -251,8 +254,9 @@ class ZabbixConn(object):
     Defines methods for managing Zabbix users and groups
 
     """
+
     def __init__(self, server, username, password):
-        self.server   = server
+        self.server = server
         self.username = username
         self.password = password
 
@@ -275,7 +279,7 @@ class ZabbixConn(object):
         try:
             self.conn.login(self.username, self.password)
         except ZabbixAPI.ZabbixAPIException as e:
-            raise SystemExit, 'Cannot login to Zabbix server: %s' % e
+            raise SystemExit('Cannot login to Zabbix server: %s' % e)
 
     def get_users(self):
         """
@@ -302,7 +306,7 @@ class ZabbixConn(object):
             The mediatypeid for specified media type description
 
         """
-        result = self.conn.mediatype.get(filter={'description':description})
+        result = self.conn.mediatype.get(filter={'description': description})
 
         if result:
             mediatypeid = result[0]['mediatypeid']
@@ -336,7 +340,7 @@ class ZabbixConn(object):
             A dict of the existing Zabbix groups and their group ids
 
         """
-        result = self.conn.usergroup.get(status=0,output='extend')
+        result = self.conn.usergroup.get(status=0, output='extend')
 
         groups = [{'name': group['name'], 'usrgrpid': group['usrgrpid']} for group in result]
 
@@ -353,12 +357,11 @@ class ZabbixConn(object):
             A list of the Zabbix users for the specified group id
 
         """
-        result = self.conn.user.get(output='extend',usrgrpids=groupid)
+        result = self.conn.user.get(output='extend', usrgrpids=groupid)
 
         users = [user['alias'] for user in result]
 
         return users
-
 
     def create_group(self, group):
         """
@@ -371,7 +374,7 @@ class ZabbixConn(object):
             The groupid of the newly created group
 
         """
-        result = self.conn.usergroup.create(name=group,permission=3)
+        result = self.conn.usergroup.create(name=group, permission=3)
 
         groupid = result['usrgrpids'].pop()
 
@@ -389,7 +392,7 @@ class ZabbixConn(object):
         """
         random_passwd = ''.join(random.sample(string.ascii_letters + string.digits, 32))
 
-        user_defaults = {'autologin': 0, 'type': 1, 'usrgrps': [ { 'usrgrpid': str(groupid) } ], 'passwd': random_passwd}
+        user_defaults = {'autologin': 0, 'type': 1, 'usrgrps': [{'usrgrpid': str(groupid)}], 'passwd': random_passwd}
         user_defaults.update(user_opt)
         user.update(user_defaults)
 
@@ -442,10 +445,16 @@ class ZabbixConn(object):
         mediatypeid = self.get_mediatype_id(description)
 
         if mediatypeid:
-            media_defaults = { 'mediatypeid': mediatypeid, 'sendto': sendto , 'active': '0', 'severity': '63', 'period': '1-7,00:00-24:00' }
+            media_defaults = {
+                'mediatypeid': mediatypeid,
+                'sendto': sendto,
+                'active': '0',
+                'severity': '63',
+                'period': '1-7,00:00-24:00'
+            }
             media_defaults.update(media_opt)
 
-            result = self.conn.user.addmedia(users=[ { "userid": str(userid) } ], medias = media_defaults)
+            result = self.conn.user.addmedia(users=[{"userid": str(userid)}], medias=media_defaults)
         else:
             result = None
 
@@ -495,7 +504,7 @@ class ZabbixConn(object):
                 # Create new user if it does not exists already
                 if eachUser not in zabbix_all_users:
                     print '>>> Creating user %s, member of Zabbix group %s' % (eachUser, eachGroup)
-                    user = { 'alias': eachUser }
+                    user = {'alias': eachUser}
                     user['name'] = ldap_conn.get_user_givenName(ldap_users[eachUser])
                     user['surname'] = ldap_conn.get_user_sn(ldap_users[eachUser])
                     self.create_user(user, zabbix_grpid, user_opt)
@@ -523,6 +532,7 @@ class ZabbixConn(object):
 
         ldap_conn.disconnect()
 
+
 class ZabbixLDAPConf(object):
     """
     Zabbix-LDAP configuration class
@@ -530,6 +540,7 @@ class ZabbixLDAPConf(object):
     Provides methods for parsing and retrieving config entries
 
     """
+
     def __init__(self, config):
         self.config = config
 
@@ -603,33 +614,33 @@ class ZabbixLDAPConf(object):
         parser.read(self.config)
 
         try:
-            self.ldap_type        = self.try_get_item(parser, 'ldap', 'type', None)
+            self.ldap_type          = self.try_get_item(parser, 'ldap', 'type', None)
 
-            self.ldap_uri         = parser.get('ldap', 'uri')
-            self.ldap_base        = parser.get('ldap', 'base')
+            self.ldap_uri           = parser.get('ldap', 'uri')
+            self.ldap_base          = parser.get('ldap', 'base')
 
-            self.ldap_groups      = [i.strip() for i in parser.get('ldap', 'groups').split(',')]
+            self.ldap_groups        = [i.strip() for i in parser.get('ldap', 'groups').split(',')]
 
-            self.ldap_user        = parser.get('ldap', 'binduser')
-            self.ldap_pass        = parser.get('ldap', 'bindpass')
+            self.ldap_user          = parser.get('ldap', 'binduser')
+            self.ldap_pass          = parser.get('ldap', 'bindpass')
 
-            self.ldap_media       = self.try_get_item(parser, 'ldap', 'media', 'mail')
+            self.ldap_media         = self.try_get_item(parser, 'ldap', 'media', 'mail')
 
-            self.zbx_server       = parser.get('zabbix', 'server')
-            self.zbx_username     = parser.get('zabbix', 'username')
-            self.zbx_password     = parser.get('zabbix', 'password')
+            self.zbx_server         = parser.get('zabbix', 'server')
+            self.zbx_username       = parser.get('zabbix', 'username')
+            self.zbx_password       = parser.get('zabbix', 'password')
 
-            self.user_opt         = self.try_get_section(parser, 'user', {})
+            self.user_opt           = self.try_get_section(parser, 'user', {})
 
-            self.media_desciption = self.try_get_item(parser, 'media', 'desciption', 'Email')
-            self.media_opt        = self.remove_config_section_items(self.try_get_section(parser, 'media', {}),
-                                                   ('description', 'userid'))
+            self.media_desciption   = self.try_get_item(parser, 'media', 'desciption', 'Email')
+            self.media_opt          = self.remove_config_section_items(self.try_get_section(parser, 'media', {}), ('description', 'userid'))
 
         except ConfigParser.NoOptionError as e:
-            raise SystemExit, 'Configuration issues detected in %s' % self.config
+            raise SystemExit('Configuration issues detected in %s' % self.config)
+
 
 def main():
-    usage="""
+    usage = """
 Usage: zabbix-ldap-sync [-ldsn] -f <config>
        zabbix-ldap-sync -v
        zabbix-ldap-sync -h
@@ -666,7 +677,7 @@ Options:
     if config.ldap_type == 'activedirectory':
         active_directory = "true"
         group_filter = "(&(objectClass=group)(name=%s))"
-        disabled_filter="(!(userAccountControl:1.2.840.113556.1.4.803:=2))"
+        disabled_filter = "(!(userAccountControl:1.2.840.113556.1.4.803:=2))"
         group_member_attribute = "member"
         uid_attribute = "sAMAccountName"
     else:


### PR DESCRIPTION
##### Fixed following issues:

* [#16 - Can't sync users with Active Directory](https://github.com/dnaeon/zabbix-ldap-sync/issues/16)
* [#18 - IndexError: pop from empty list](https://github.com/dnaeon/zabbix-ldap-sync/issues/18)

Now, `Distinguished Name` is used everywhere for lookups. Tested with Active Directory/OpenLDAP.

##### Implemented via additional command-line arguments (off by default):

* [#12 - zabbix-ldap-sync donot delete user](https://github.com/dnaeon/zabbix-ldap-sync/issues/12). Controlled by `-d, --delete-orphans` command-line argument.
* [#17 - Zabbix Running on SSL - Suport Unverified Certs](https://github.com/dnaeon/zabbix-ldap-sync/issues/17). Controlled by `-n, --no-check-certificate` command-line argument.
* [#19 - Disabled users imported to zabbix](https://github.com/dnaeon/zabbix-ldap-sync/issues/19). Controlled by `-s, --skip-disabled` command-line argument.

Fix for #17 is not tested by me, since my Zabbix instance runs on plain `http`.

##### New features:

* Ablity to specify custom user properites in configuration file. See [User object](https://www.zabbix.com/documentation/3.2/manual/api/reference/user/object) in Zabbix API documentation for available properties.
* Ablity to specify custom media type/properties in configuration file. See [Media object](https://www.zabbix.com/documentation/3.2/manual/api/reference/usermedia/object#media) in Zabbix API documentation for available properties.

##### Documentation:

* `README.md` is updated with info about new configuration file sections and command-line arguments.

##### Breaking changes:

* `mail` configuration entry in `[ldap]` sections is renamed to `media`

It shoudn't actually break anything, since it wasn't mentioned in readme/config, and was only used internally with default value, but nonetheless.
