### PR TITLE
Correcting typo - descRiption

### DIFF
--- a/zabbix-ldap-sync
+++ b/zabbix-ldap-sync
@@ -689,7 +689,7 @@ class ZabbixLDAPConf(object):
 
             self.user_opt           = self.try_get_section(parser, 'user', {})
 
-            self.media_desciption   = self.try_get_item(parser, 'media', 'desciption', 'Email')
+            self.media_desciption   = self.try_get_item(parser, 'media', 'description', 'Email')
             self.media_opt          = self.remove_config_section_items(self.try_get_section(parser, 'media', {}), ('description', 'userid'))
 
         except ConfigParser.NoOptionError as e:


### PR DESCRIPTION
bug fix:
- value Description do not  load from configuration file. Typo