### PR TITLE
fix bug - cannot update user media after user deleted

### DIFF
--- a/zabbix-ldap-sync
+++ b/zabbix-ldap-sync
@@ -633,6 +633,7 @@ class ZabbixConn(object):
                         print ' * %s' % eachUser
 
             # update users media
+            zabbix_group_users = self.get_group_members(zabbix_grpid)
             for eachUser in set(zabbix_group_users):
                 print '>>> Updating user media for %s, update %s' % (eachUser, media_description)
                 sendto = ldap_conn.get_user_media(ldap_users[eachUser], ldap_media)


### PR DESCRIPTION
fix bug - cannot update user media after user deleted

Traceback (most recent call last):
  File "zabbix-ldap-sync", line 868, in <module>
    main()
  File "zabbix-ldap-sync", line 865, in main
    config.media_opt)
  File "zabbix-ldap-sync", line 638, in sync_users
    sendto = ldap_conn.get_user_media(ldap_users[eachUser], ldap_media)
KeyError: u'allburov'