### PR TITLE
Basic auth and python 3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *~
 \#*
+zabbix-ldap-*.conf

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Check the official documentation of Zabbix on how to
 ### Setup virtualenv
 
 ```
-apt-get install python-dev virtualenv
+apt-get install python-dev virtualenv libpython3.6-dev libldap2-dev libsasl2-dev
 virtualenv -p python3 env
 source env/bin/activate
 pip install python3-ldap

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It can automatically import existing LDAP groups and users into Zabbix, thus mak
 
 ## Requirements
 
-* Python 2.7.x
+* Python 3.x.x
 * [python-ldap](https://pypi.python.org/pypi/python-ldap/)
 * [pyzabbix](https://github.com/lukecyca/pyzabbix)
 * [docopt](https://github.com/docopt/docopt)
@@ -68,6 +68,7 @@ In order to use the *zabbix-ldap-sync* script we need to create a configuration 
 * `server` - Zabbix URL
 * `username` - Zabbix username. This user must have permissions to add/remove users and groups. Typically, this would be `Zabbix Admin` account.
 * `password` - Password for Zabbix user
+* `auth` - can be `http` (for basic auth) or `webform` (for regular form based login)
 
 #### [user]
 Allows to override various properties for Zabbix users created by script. See [User object](https://www.zabbix.com/documentation/3.2/manual/api/reference/user/object) in Zabbix API documentation for available properties. If section/property doesn't exist, defaults are:

--- a/README.md
+++ b/README.md
@@ -23,9 +23,21 @@ You also need to have your Zabbix Frontend configured to authenticate against an
 Check the official documentation of Zabbix on how to 
 [configure Zabbix to authenticate against an AD/LDAP directory server](https://www.zabbix.com/documentation/2.2/manual/web_interface/frontend_sections/administration/authentication).
 
+### Setup virtualenv
+
+```
+apt-get install python-dev virtualenv
+virtualenv -p python3 env
+source env/bin/activate
+pip install python3-ldap
+pip install pyzabbix
+pip install docopt
+```
+
 ## Configuration
 
 In order to use the *zabbix-ldap-sync* script we need to create a configuration file describing the various LDAP and Zabbix related config entries.
+
 ### Config file sections
 
 #### [ldap]
@@ -124,7 +136,6 @@ You can configure additional properties in this section. See [Media object](http
     active = 0
     period = 1-5,07:00-22:00
     severity = 63
-
 
 ## Command-line arguments
 

--- a/README.md
+++ b/README.md
@@ -95,8 +95,10 @@ You can configure additional properties in this section. See [Media object](http
 ║  Enabled ?  ║      1 ║  1 ║     1 ║     1 ║         1 ║            1 ║
 ╠═════════════╬════════╩════╩═══════╩═══════╩═══════════╩══════════════╣
 ║Decimal value║                     111111 = 63                        ║
+║             ║           Linux: printf '%x\n' "$((2#111000))"         ║
 ╚═════════════╩════════════════════════════════════════════════════════╝
 ```
+
 
 ## Configuration file example
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ In order to use the *zabbix-ldap-sync* script we need to create a configuration 
 * `groups` - LDAP groups to sync with Zabbix (support wildcard - TESTED ONLY with Active Directory, see Command-line arguments)
 * `media` - Name of the LDAP attribute of user object, that will be used to set `Send to` property of Zabbix user media. This entry is optional, default value is `mail`.
 
-[ad]
+#### [ad]
 * `filtergroup` = The ldap filter to get group in ActiveDirectory mode, by default `(&(objectClass=group)(name=%s))`
 * `filteruser` = The ldap filter to get the users in ActiveDirectory mode, by default `(objectClass=user)(objectCategory=Person)`
 * `filterdisabled` = The filter to get the disabled user in ActiveDirectory mode, by default `(!(userAccountControl:1.2.840.113556.1.4.803:=2))`
@@ -59,7 +59,7 @@ In order to use the *zabbix-ldap-sync* script we need to create a configuration 
 * `groupattribute` = The attribute used for membership in a group in ActiveDirectory mode, by default `member`
 * `userattribute` = The attribute for users in ActiveDirectory mode `sAMAccountName`
 
-[openldap]
+#### [openldap]
 * `type` = The storage mode for group and users can be `posix` or `groupofnames` 
 * `filtergroup` = The ldap filter to get group in OpenLDAP mode, by default `(&(objectClass=posixGroup)(cn=%s))`
 * `filteruser` = The ldap filter to get the users in OpenLDAP mode, by default `(&(objectClass=posixAccount)(uid=%s))`
@@ -95,7 +95,7 @@ You can configure additional properties in this section. See [Media object](http
 ║  Enabled ?  ║      1 ║  1 ║     1 ║     1 ║         1 ║            1 ║
 ╠═════════════╬════════╩════╩═══════╩═══════╩═══════════╩══════════════╣
 ║Decimal value║                     111111 = 63                        ║
-║             ║           Linux: printf '%x\n' "$((2#111000))"         ║
+║             ║           Linux: printf '%i\n' "$((2#111111))"         ║
 ╚═════════════╩════════════════════════════════════════════════════════╝
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ It can automatically import existing LDAP groups and users into Zabbix, thus mak
 ## Requirements
 
 * Python 3.x.x
-* [python-ldap](https://pypi.python.org/pypi/python-ldap/)
+* [pyldap](https://pypi.python.org/pypi/pyldap/)
 * [pyzabbix](https://github.com/lukecyca/pyzabbix)
 * [docopt](https://github.com/docopt/docopt)
+* Zabbix 3.4
 
 You also need to have your Zabbix Frontend configured to authenticate against an AD/LDAP directory server.
+(using http or ldap-auth)
 
 Check the official documentation of Zabbix on how to 
 [configure Zabbix to authenticate against an AD/LDAP directory server](https://www.zabbix.com/documentation/2.2/manual/web_interface/frontend_sections/administration/authentication).
@@ -29,7 +31,7 @@ Check the official documentation of Zabbix on how to
 apt-get install python-dev virtualenv libpython3.6-dev libldap2-dev libsasl2-dev
 virtualenv -p python3 env
 source env/bin/activate
-pip install python3-ldap
+pip install pyldap
 pip install pyzabbix
 pip install docopt
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-python-ldap
+python3-ldap
 pyzabbix
 docopt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-python3-ldap
+pyldap
 pyzabbix
 docopt

--- a/zabbix-ldap-sync
+++ b/zabbix-ldap-sync
@@ -28,15 +28,15 @@
 The zabbix-ldap-sync script is used for syncing LDAP users with Zabbix.
 
 """
-
+from pprint import pprint
 import random
 import string
 import logging
 import configparser
 import sys
-import ldap3
+import ldap
+import ldap.filter
 import traceback
-#import ldap3.filter
 from pyzabbix import ZabbixAPI, ZabbixAPIException
 from docopt import docopt
 
@@ -63,12 +63,12 @@ class LDAPConn(object):
             SystemExit
 
         """
-        self.conn = ldap3.initialize(self.uri)
-        self.conn.set_option(ldap3.OPT_REFERRALS, ldap3.OPT_OFF)
+        self.conn = ldap.initialize(self.uri)
+        self.conn.set_option(ldap.OPT_REFERRALS, ldap.OPT_OFF)
 
         try:
             self.conn.simple_bind_s(self.ldap_user, self.ldap_pass)
-        except ldap3.SERVER_DOWN as e:
+        except ldap.SERVER_DOWN as e:
             raise SystemExit('Cannot connect to LDAP server: %s' % e)
 
     def disconnect(self):
@@ -100,13 +100,17 @@ class LDAPConn(object):
         filter = group_filter % group
 
         result = self.conn.search_s(base=self.base,
-                                    scope=ldap3.SCOPE_SUBTREE,
+                                    scope=ldap.SCOPE_SUBTREE,
                                     filterstr=filter,
                                     attrlist=attrlist)
 
         if not result:
-            print('>>> Unable to find group %s, skipping group' % group)
+            print('>>> Unable to find group "%s" with filter "%s", skipping group' % (group,filter))
             return None
+
+        print("*******************************************")
+        pprint(result)
+        print("*******************************************")
 
         # Get DN for each user in the group
         if active_directory:
@@ -134,9 +138,11 @@ class LDAPConn(object):
                     filter = "(&%s%s)" % (user_filter, member_of_filter_dn)
 
                 uid = self.conn.search_s(base=self.base,
-                                         scope=ldap3.SCOPE_SUBTREE,
+                                         scope=ldap.SCOPE_SUBTREE,
                                          filterstr=filter,
                                          attrlist=attrlist)
+
+
 
                 for item in self.remove_ad_referrals(uid):
                     group_members.append(item)
@@ -149,7 +155,7 @@ class LDAPConn(object):
                         filter = "(&%s)" % user_filter
 
                     uid = self.conn.search_s(base=member,
-                                             scope=ldap3.SCOPE_BASE,
+                                             scope=ldap.SCOPE_BASE,
                                              filterstr=filter,
                                              attrlist=attrlist)
                     for item in uid:
@@ -161,11 +167,12 @@ class LDAPConn(object):
                 username = item[1][uid_attribute]
 
                 if lowercase:
-                    username = str(username)[2: -2].lower()
+                    username = username[0].decode('ascii').lower()
                 else:
-                    username = str(username)[2: -2]
+                    username = username[0].decode('ascii')
 
                 final_listing[username] = dn
+                pprint(dn)
 
             return final_listing
 
@@ -196,7 +203,7 @@ class LDAPConn(object):
 
                 # get the actual LDAP object for each group member
                 uid = self.conn.search_s(base=base,
-                                          scope=ldap3.SCOPE_SUBTREE,
+                                          scope=ldap.SCOPE_SUBTREE,
                                           filterstr=filter,
                                           attrlist=attrlist)
 
@@ -211,6 +218,7 @@ class LDAPConn(object):
 
                 final_listing[user] = dn
 
+
             return final_listing
 
     def get_groups_with_wildcard(self, groups_wildcard):
@@ -220,7 +228,7 @@ class LDAPConn(object):
         result_groups=[]
 
         result = self.conn.search_s(base=self.base,
-                                    scope=ldap3.SCOPE_SUBTREE,
+                                    scope=ldap.SCOPE_SUBTREE,
                                     filterstr=filter,)
 
         for group in result:
@@ -232,7 +240,7 @@ class LDAPConn(object):
                 result_groups.append(group_name)
 
         if not result_groups:
-            print('>>> Unable to find group %s, skipping group wildcard' % groups_wildcard)
+            print('>>> Unable to find group "%s", skipping group wildcard' % groups_wildcard)
 
         return result_groups
 
@@ -253,7 +261,7 @@ class LDAPConn(object):
         attrlist = [ldap_media]
 
         result = self.conn.search_s(base=dn,
-                                    scope=ldap3.SCOPE_BASE,
+                                    scope=ldap.SCOPE_BASE,
                                     attrlist=attrlist)
 
         if not result:
@@ -282,7 +290,7 @@ class LDAPConn(object):
         attrlist = ['sn']
 
         result = self.conn.search_s(base=dn,
-                                    scope=ldap3.SCOPE_BASE,
+                                    scope=ldap.SCOPE_BASE,
                                     attrlist=attrlist)
 
         if not result:
@@ -311,7 +319,7 @@ class LDAPConn(object):
         attrlist = ['givenName']
 
         result = self.conn.search_s(base=dn,
-                                    scope=ldap3.SCOPE_BASE,
+                                    scope=ldap.SCOPE_BASE,
                                     attrlist=attrlist)
 
         if not result:
@@ -482,7 +490,7 @@ class ZabbixConn(object):
             The groupid of the newly created group
 
         """
-        result = self.conn.usergroup.create(name=group, permission=0)
+        result = self.conn.usergroup.create(name=group)
 
         groupid = result['usrgrpids'].pop()
 
@@ -617,6 +625,7 @@ class ZabbixConn(object):
 
         zabbix_all_users = self.get_users()
 
+
         for eachGroup in ldap_groups:
             ldap_users = ldap_conn.get_group_members(eachGroup)
 
@@ -628,22 +637,31 @@ class ZabbixConn(object):
 
             zabbix_group_users = self.get_group_members(zabbix_grpid)
 
+
+
             missing_users = set(list(ldap_users.keys())) - set(zabbix_group_users)
+
 
             # Add missing users
             for eachUser in missing_users:
 
                 # Create new user if it does not exists already
                 if eachUser not in zabbix_all_users:
-                    print('>>> Creating user %s, member of Zabbix group %s' % (eachUser, eachGroup))
+                    print('>>> Creating user "%s", member of Zabbix group "%s"' % (eachUser, eachGroup))
                     user = {'alias': eachUser}
                     user['name'] = ldap_conn.get_user_givenName(ldap_users[eachUser])
                     user['surname'] = ldap_conn.get_user_sn(ldap_users[eachUser])
+
+                    if user['name'] is None:
+                      user['name'] = ''
+                    if user['surname'] is None:
+                      user['surname'] = ''
+
                     self.create_user(user, zabbix_grpid, user_opt)
                     zabbix_all_users.append(eachUser)
                 else:
                     # Update existing user to be member of the group
-                    print('>>> Updating user %s, adding to group %s' % (eachUser, eachGroup))
+                    print('>>> Updating user "%s", adding to group "%s"' % (eachUser, eachGroup))
                     self.update_user(eachUser, zabbix_grpid)
 
             # Handle any extra users in the groups
@@ -653,7 +671,7 @@ class ZabbixConn(object):
 
                 for eachUser in extra_users:
                     if deleteorphans:
-                        print('Deleting user: %s' % eachUser)
+                        print('Deleting user: "%s"' % eachUser)
                         self.delete_user(eachUser)
                     else:
                         print(' * %s' % eachUser)
@@ -661,7 +679,7 @@ class ZabbixConn(object):
             # update users media
             zabbix_group_users = self.get_group_members(zabbix_grpid)
             for eachUser in set(zabbix_group_users):
-                print('>>> Updating user media for %s, update %s' % (eachUser, media_description))
+                print('>>> Updating user media for "%s", update "%s"' % (eachUser, media_description))
                 sendto = ldap_conn.get_user_media(ldap_users[eachUser], ldap_media)
 
                 if sendto:

--- a/zabbix-ldap-sync
+++ b/zabbix-ldap-sync
@@ -623,7 +623,7 @@ class ZabbixConn(object):
         zabbix_all_users = self.get_users()
 
         for eachGroup in ldap_groups:
-            print(eachGroup)
+
             ldap_users = ldap_conn.get_group_members(eachGroup)
 
             # Do nothing if LDAP group contains no users and "--delete-orphans" is not specified
@@ -885,7 +885,6 @@ Options:
         group_member_attribute = config.openldap_groupattribute
         uid_attribute = config.openldap_userattribute
 
-    print(uid_attribute)
     wildcard_search = args['--wildcard-search']
     if wildcard_search:
         config.set_groups_with_wildcard()

--- a/zabbix-ldap-sync
+++ b/zabbix-ldap-sync
@@ -32,10 +32,11 @@ The zabbix-ldap-sync script is used for syncing LDAP users with Zabbix.
 import random
 import string
 import logging
-import ConfigParser
+import configparser
 import sys
-import ldap
-import ldap.filter
+import ldap3
+import traceback
+#import ldap3.filter
 from pyzabbix import ZabbixAPI, ZabbixAPIException
 from docopt import docopt
 
@@ -62,12 +63,12 @@ class LDAPConn(object):
             SystemExit
 
         """
-        self.conn = ldap.initialize(self.uri)
-        self.conn.set_option(ldap.OPT_REFERRALS, ldap.OPT_OFF)
+        self.conn = ldap3.initialize(self.uri)
+        self.conn.set_option(ldap3.OPT_REFERRALS, ldap3.OPT_OFF)
 
         try:
             self.conn.simple_bind_s(self.ldap_user, self.ldap_pass)
-        except ldap.SERVER_DOWN as e:
+        except ldap3.SERVER_DOWN as e:
             raise SystemExit('Cannot connect to LDAP server: %s' % e)
 
     def disconnect(self):
@@ -99,7 +100,7 @@ class LDAPConn(object):
         filter = group_filter % group
 
         result = self.conn.search_s(base=self.base,
-                                    scope=ldap.SCOPE_SUBTREE,
+                                    scope=ldap3.SCOPE_SUBTREE,
                                     filterstr=filter,
                                     attrlist=attrlist)
 
@@ -133,7 +134,7 @@ class LDAPConn(object):
                     filter = "(&%s%s)" % (user_filter, member_of_filter_dn)
 
                 uid = self.conn.search_s(base=self.base,
-                                         scope=ldap.SCOPE_SUBTREE,
+                                         scope=ldap3.SCOPE_SUBTREE,
                                          filterstr=filter,
                                          attrlist=attrlist)
 
@@ -148,7 +149,7 @@ class LDAPConn(object):
                         filter = "(&%s)" % user_filter
 
                     uid = self.conn.search_s(base=member,
-                                             scope=ldap.SCOPE_BASE,
+                                             scope=ldap3.SCOPE_BASE,
                                              filterstr=filter,
                                              attrlist=attrlist)
                     for item in uid:
@@ -195,7 +196,7 @@ class LDAPConn(object):
 
                 # get the actual LDAP object for each group member
                 uid = self.conn.search_s(base=base,
-                                          scope=ldap.SCOPE_SUBTREE,
+                                          scope=ldap3.SCOPE_SUBTREE,
                                           filterstr=filter,
                                           attrlist=attrlist)
 
@@ -219,7 +220,7 @@ class LDAPConn(object):
         result_groups=[]
 
         result = self.conn.search_s(base=self.base,
-                                    scope=ldap.SCOPE_SUBTREE,
+                                    scope=ldap3.SCOPE_SUBTREE,
                                     filterstr=filter,)
 
         for group in result:
@@ -252,7 +253,7 @@ class LDAPConn(object):
         attrlist = [ldap_media]
 
         result = self.conn.search_s(base=dn,
-                                    scope=ldap.SCOPE_BASE,
+                                    scope=ldap3.SCOPE_BASE,
                                     attrlist=attrlist)
 
         if not result:
@@ -281,7 +282,7 @@ class LDAPConn(object):
         attrlist = ['sn']
 
         result = self.conn.search_s(base=dn,
-                                    scope=ldap.SCOPE_BASE,
+                                    scope=ldap3.SCOPE_BASE,
                                     attrlist=attrlist)
 
         if not result:
@@ -310,7 +311,7 @@ class LDAPConn(object):
         attrlist = ['givenName']
 
         result = self.conn.search_s(base=dn,
-                                    scope=ldap.SCOPE_BASE,
+                                    scope=ldap3.SCOPE_BASE,
                                     attrlist=attrlist)
 
         if not result:
@@ -334,10 +335,11 @@ class ZabbixConn(object):
 
     """
 
-    def __init__(self, server, username, password):
+    def __init__(self, server, username, password, auth):
         self.server = server
         self.username = username
         self.password = password
+        self.auth = auth
 
     def verbose(self):
         # Use logger to log information
@@ -368,7 +370,14 @@ class ZabbixConn(object):
 
         """
 
-        self.conn = ZabbixAPI(self.server)
+        if self.auth == "webform":
+            self.conn = ZabbixAPI(self.server)
+        elif self.auth == "http":
+            self.conn = ZabbixAPI(self.server, use_authenticate=False)
+            self.conn.session.auth = (self.username, self.password)
+
+        else:
+            raise SystemExit('api auth method not implemented: %s' % self.conn.auth)
 
         if nocheckcertificate:
             self.conn.session.verify = False
@@ -377,6 +386,8 @@ class ZabbixConn(object):
             self.conn.login(self.username, self.password)
         except ZabbixAPIException as e:
             raise SystemExit('Cannot login to Zabbix server: %s' % e)
+
+        print("Connected to Zabbix API Version %s" % self.conn.api_version())
 
     def get_users(self):
         """
@@ -471,7 +482,7 @@ class ZabbixConn(object):
             The groupid of the newly created group
 
         """
-        result = self.conn.usergroup.create(name=group, permission=3)
+        result = self.conn.usergroup.create(name=group, permission=0)
 
         groupid = result['usrgrpids'].pop()
 
@@ -687,7 +698,7 @@ class ZabbixLDAPConf(object):
 
         try:
             result = parser.get(section, option)
-        except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
+        except (configparser.NoOptionError, configparser.NoSectionError):
             result = default
 
         return result
@@ -708,7 +719,7 @@ class ZabbixLDAPConf(object):
 
         try:
             result = parser.items(section)
-        except ConfigParser.NoSectionError:
+        except configparser.NoSectionError:
             result = default
 
         return result
@@ -736,7 +747,7 @@ class ZabbixLDAPConf(object):
             ConfigParser.NoOptionError
 
         """
-        parser = ConfigParser.ConfigParser()
+        parser = configparser.ConfigParser()
         parser.read(self.config)
 
         try:
@@ -752,29 +763,32 @@ class ZabbixLDAPConf(object):
 
             self.ldap_media         = self.try_get_item(parser, 'ldap', 'media', 'mail')
 
-            self.ad_filtergroup = parser.get ('ad', 'filtergroup','(&(objectClass=group)(name=%s))')
-            self.ad_filteruser = parser.get ('ad','filteruser', '(objectClass=user)(objectCategory=Person))')
-            self.ad_filterdisabled = parser.get ('ad', 'filterdisabled','(!(userAccountControl:1.2.840.113556.1.4.803:=2))')
-            self.ad_filtermemberof = parser.get ('ad', 'filtermemberof','(memberOf:1.2.840.113556.1.4.1941:=%s)')
-            self.ad_groupattribute = parser.get ('ad', 'groupattribute','member')
-            self.ad_userattribute = parser.get ('ad', 'userattribute','sAMAccountName')
+            self.ad_filtergroup = parser.get('ad', 'filtergroup',fallback='(&(objectClass=group)(name=%s))', raw=True)
+            self.ad_filteruser = parser.get('ad','filteruser', fallback='(objectClass=user)(objectCategory=Person))', raw=True)
+            self.ad_filterdisabled = parser.get('ad', 'filterdisabled',fallback='(!(userAccountControl:1.2.840.113556.1.4.803:=2))', raw=True)
+            self.ad_filtermemberof = parser.get('ad', 'filtermemberof',fallback='(memberOf:1.2.840.113556.1.4.1941:=%s)', raw=True)
+            self.ad_groupattribute = parser.get('ad', 'groupattribute',fallback='member', raw=True)
+            self.ad_userattribute = parser.get('ad', 'userattribute',fallback='sAMAccountName', raw=True)
 
-            self.openldap_type = parser.get ('openldap', 'type','posixgroup')
-            self.openldap_filtergroup = parser.get ('openldap', 'filtergroup','(&(objectClass=posixGroup)(cn=%s))')
-            self.openldap_filteruser = parser.get ('openldap', 'filteruser','(&(objectClass=posixAccount)(uid=%s))')
-            self.openldap_groupattribute = parser.get ('openldap', 'groupattribute','memberUid')
-            self.openldap_userattribute = parser.get ('openldap', 'userattribute','uid')
+            self.openldap_type = parser.get('openldap', 'type',fallback='posixgroup')
+            self.openldap_filtergroup = parser.get('openldap', 'filtergroup',fallback='(&(objectClass=posixGroup)(cn=%s))',raw=True)
+            self.openldap_filteruser = parser.get('openldap', 'filteruser',fallback='(&(objectClass=posixAccount)(uid=%s))',raw=True)
+            self.openldap_groupattribute = parser.get('openldap', 'groupattribute',fallback='memberUid', raw=True)
+            self.openldap_userattribute = parser.get('openldap', 'userattribute',fallback='uid', raw=True)
 
             self.zbx_server         = parser.get('zabbix', 'server')
             self.zbx_username       = parser.get('zabbix', 'username')
             self.zbx_password       = parser.get('zabbix', 'password')
+            self.zbx_auth           = parser.get('zabbix', 'auth')
 
             self.user_opt           = self.try_get_section(parser, 'user', {})
 
             self.media_description   = self.try_get_item(parser, 'media', 'description', 'Email')
             self.media_opt          = self.remove_config_section_items(self.try_get_section(parser, 'media', {}), ('description', 'userid'))
 
-        except ConfigParser.NoOptionError as e:
+        except Exception as e:
+            print(e)
+            traceback.print_exc(file=sys.stderr)
             raise SystemExit('Configuration issues detected in %s' % self.config)
 
     def set_groups_with_wildcard(self):
@@ -864,7 +878,7 @@ Options:
         from requests.packages.urllib3 import disable_warnings
         disable_warnings()
 
-    zabbix_conn = ZabbixConn(config.zbx_server, config.zbx_username, config.zbx_password)
+    zabbix_conn = ZabbixConn(config.zbx_server, config.zbx_username, config.zbx_password, config.zbx_auth)
     if verbose:
         zabbix_conn.verbose()
     zabbix_conn.connect(nocheckcertificate)

--- a/zabbix-ldap-sync
+++ b/zabbix-ldap-sync
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 #
 # Copyright (c) 2013-2014 Marin Atanasov Nikolov <dnaeon@gmail.com>
+# Copyright (c) 2013-2014 Marc Schöchlin<ms@256bit.org>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -108,10 +109,6 @@ class LDAPConn(object):
             print('>>> Unable to find group "%s" with filter "%s", skipping group' % (group,filter))
             return None
 
-        print("*******************************************")
-        pprint(result)
-        print("*******************************************")
-
         # Get DN for each user in the group
         if active_directory:
 
@@ -154,7 +151,7 @@ class LDAPConn(object):
                     else:
                         filter = "(&%s)" % user_filter
 
-                    uid = self.conn.search_s(base=member,
+                    uid = self.conn.search_s(base=member.decode('utf8'),
                                              scope=ldap.SCOPE_BASE,
                                              filterstr=filter,
                                              attrlist=attrlist)
@@ -172,7 +169,6 @@ class LDAPConn(object):
                     username = username[0].decode('ascii')
 
                 final_listing[username] = dn
-                pprint(dn)
 
             return final_listing
 
@@ -557,6 +553,7 @@ class ZabbixConn(object):
 
         """
 
+
         userid = self.get_user_id(user)
         mediatypeid = self.get_mediatype_id(description)
 
@@ -625,8 +622,8 @@ class ZabbixConn(object):
 
         zabbix_all_users = self.get_users()
 
-
         for eachGroup in ldap_groups:
+            print(eachGroup)
             ldap_users = ldap_conn.get_group_members(eachGroup)
 
             # Do nothing if LDAP group contains no users and "--delete-orphans" is not specified
@@ -649,8 +646,8 @@ class ZabbixConn(object):
                 if eachUser not in zabbix_all_users:
                     print('>>> Creating user "%s", member of Zabbix group "%s"' % (eachUser, eachGroup))
                     user = {'alias': eachUser}
-                    user['name'] = ldap_conn.get_user_givenName(ldap_users[eachUser])
-                    user['surname'] = ldap_conn.get_user_sn(ldap_users[eachUser])
+                    user['name'] = ldap_conn.get_user_givenName(ldap_users[eachUser]).decode('utf8')
+                    user['surname'] = ldap_conn.get_user_sn(ldap_users[eachUser]).decode('utf8')
 
                     if user['name'] is None:
                       user['name'] = ''
@@ -680,7 +677,7 @@ class ZabbixConn(object):
             zabbix_group_users = self.get_group_members(zabbix_grpid)
             for eachUser in set(zabbix_group_users):
                 print('>>> Updating user media for "%s", update "%s"' % (eachUser, media_description))
-                sendto = ldap_conn.get_user_media(ldap_users[eachUser], ldap_media)
+                sendto = ldap_conn.get_user_media(ldap_users[eachUser], ldap_media).decode("utf-8")
 
                 if sendto:
                     self.update_media(eachUser, media_description, sendto, media_opt)
@@ -888,6 +885,7 @@ Options:
         group_member_attribute = config.openldap_groupattribute
         uid_attribute = config.openldap_userattribute
 
+    print(uid_attribute)
     wildcard_search = args['--wildcard-search']
     if wildcard_search:
         config.set_groups_with_wildcard()

--- a/zabbix-ldap-sync
+++ b/zabbix-ldap-sync
@@ -164,9 +164,9 @@ class LDAPConn(object):
                 username = item[1][uid_attribute]
 
                 if lowercase:
-                    username = username[0].decode('ascii').lower()
+                    username = username[0].decode('utf8').lower()
                 else:
-                    username = username[0].decode('ascii')
+                    username = username[0].decode('utf8')
 
                 final_listing[username] = dn
 
@@ -677,7 +677,7 @@ class ZabbixConn(object):
             zabbix_group_users = self.get_group_members(zabbix_grpid)
             for eachUser in set(zabbix_group_users):
                 print('>>> Updating user media for "%s", update "%s"' % (eachUser, media_description))
-                sendto = ldap_conn.get_user_media(ldap_users[eachUser], ldap_media).decode("utf-8")
+                sendto = ldap_conn.get_user_media(ldap_users[eachUser], ldap_media).decode("utf8")
 
                 if sendto:
                     self.update_media(eachUser, media_description, sendto, media_opt)

--- a/zabbix-ldap-sync
+++ b/zabbix-ldap-sync
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (c) 2013-2014 Marin Atanasov Nikolov <dnaeon@gmail.com>
 # All rights reserved.
@@ -104,7 +104,7 @@ class LDAPConn(object):
                                     attrlist=attrlist)
 
         if not result:
-            print '>>> Unable to find group %s, skipping group' % group
+            print('>>> Unable to find group %s, skipping group' % group)
             return None
 
         # Get DN for each user in the group
@@ -577,7 +577,7 @@ class ZabbixConn(object):
             media_ids = [int(u['mediaid']) for u in user_full[0]['medias'] if u['mediatypeid'] == mediatypeid]
 
             if media_ids:
-                print '>>> Remove other exist media from user %s (type=%s)' % (user, description)
+                print('>>> Remove other exist media from user %s (type=%s)' % (user, description))
                 for id in media_ids:
                     self.conn.user.deletemedia(id)
 
@@ -592,9 +592,9 @@ class ZabbixConn(object):
         missing_groups = set(ldap_groups) - set([g['name'] for g in self.get_groups()])
 
         for eachGroup in missing_groups:
-            print '>>> Creating Zabbix group %s' % eachGroup
+            print('>>> Creating Zabbix group %s' % eachGroup)
             grpid = self.create_group(eachGroup)
-            print '>>> Group %s created with groupid %s' % (eachGroup, grpid)
+            print('>>> Group %s created with groupid %s' % (eachGroup, grpid))
 
     def sync_users(self, ldap_uri, ldap_base, ldap_groups, ldap_user, ldap_pass, ldap_media, user_opt, media_description, media_opt):
         """
@@ -624,7 +624,7 @@ class ZabbixConn(object):
 
                 # Create new user if it does not exists already
                 if eachUser not in zabbix_all_users:
-                    print '>>> Creating user %s, member of Zabbix group %s' % (eachUser, eachGroup)
+                    print('>>> Creating user %s, member of Zabbix group %s' % (eachUser, eachGroup))
                     user = {'alias': eachUser}
                     user['name'] = ldap_conn.get_user_givenName(ldap_users[eachUser])
                     user['surname'] = ldap_conn.get_user_sn(ldap_users[eachUser])
@@ -632,25 +632,25 @@ class ZabbixConn(object):
                     zabbix_all_users.append(eachUser)
                 else:
                     # Update existing user to be member of the group
-                    print '>>> Updating user %s, adding to group %s' % (eachUser, eachGroup)
+                    print('>>> Updating user %s, adding to group %s' % (eachUser, eachGroup))
                     self.update_user(eachUser, zabbix_grpid)
 
             # Handle any extra users in the groups
             extra_users = set(zabbix_group_users) - set(list(ldap_users.keys()))
             if extra_users:
-                print '>>> Users in group %s which are not found in LDAP group:' % eachGroup
+                print('>>> Users in group %s which are not found in LDAP group:' % eachGroup)
 
                 for eachUser in extra_users:
                     if deleteorphans:
-                        print 'Deleting user: %s' % eachUser
+                        print('Deleting user: %s' % eachUser)
                         self.delete_user(eachUser)
                     else:
-                        print ' * %s' % eachUser
+                        print(' * %s' % eachUser)
 
             # update users media
             zabbix_group_users = self.get_group_members(zabbix_grpid)
             for eachUser in set(zabbix_group_users):
-                print '>>> Updating user media for %s, update %s' % (eachUser, media_description)
+                print('>>> Updating user media for %s, update %s' % (eachUser, media_description))
                 sendto = ldap_conn.get_user_media(ldap_users[eachUser], ldap_media)
 
                 if sendto:

--- a/zabbix-ldap.conf
+++ b/zabbix-ldap.conf
@@ -25,6 +25,7 @@ userattribute = uid
 server = http://zabbix.example.org/zabbix/
 username = admin
 password = adminp4ssw0rd
+auth = webform
 
 [user]
 type = 1


### PR DESCRIPTION
This pull request introduces support for http/basic based api auth and a port to python 3.

This is the first set of changes, future improvements might be:

- relocate the included classes to dedicated class files
- provide a possibility to configure dedicated media/user settings per group
- provide the possibility to only set media settings on user creation
- convert all commandline switches to configfile settings
- configure the severity without manual binary to decimal conversion
- ....

You described that you might transfer the maintainership to interested developers.
I'm interested :-) Should i create a github organization/group to manage this project?


